### PR TITLE
rel: update landlord to 0.11.0 for MOM cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/mtgoncurve/mtgoncurve.com#readme",
   "dependencies": {
-    "@mtgoncurve/landlord": "^0.10.0",
+    "@mtgoncurve/landlord": "^0.11.0",
     "bulma": "^0.8.0",
     "mana-font": "^1.6.0",
     "terser": "^4.6.7",


### PR DESCRIPTION
Trying again for MOM, depends on https://github.com/mtgoncurve/landlord/pull/48