### PR TITLE
rel: update landlord to 0.13.0 for WOE cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/mtgoncurve/mtgoncurve.com#readme",
   "dependencies": {
-    "@mtgoncurve/landlord": "^0.12.0",
+    "@mtgoncurve/landlord": "^0.13.0",
     "bulma": "^0.8.0",
     "mana-font": "^1.6.0",
     "terser": "^4.6.7",


### PR DESCRIPTION
Submitting this one a bit ahead of the WOE release, depends on https://github.com/mtgoncurve/landlord/pull/50