### PR TITLE
refactor(input) change "on the play" checkbox into a "first turn" radio button

### DIFF
--- a/src/InputPanel.vue
+++ b/src/InputPanel.vue
@@ -81,10 +81,15 @@ Runaway Steam-Kin
       ></textarea>
       </div>
 
-      <label class="label is-small">On the play</label>
-      <div class="field">
-        <input type="checkbox" value="true" v-model="on_the_play" />
-      </div>
+      <fieldset>
+        <legend class="label is-small">First turn</legend>
+        <div class="field">
+          <input type="radio" value="true" v-model="on_the_play" />
+          <label >On the play</label>
+          <input type="radio" value="false" v-model="on_the_play" />
+          <label >On the draw</label>
+        </div>
+      </fieldset>
     </div>
   </div>
 </template>
@@ -137,7 +142,7 @@ export default {
         return this.$store.state.inputs.on_the_play;
       },
       set(val) {
-        this.$store.dispatch("update", { on_the_play: val });
+        this.$store.dispatch("update", { on_the_play: val == "true" });
       }
     },
     mulligan_down_to: {


### PR DESCRIPTION
fixes #81

this keeps the same interface for the WASM landlord simulation, but refactors the UI to try to more intuitively explain the idea of how the simulation models the first turn ("on the play" vs "on the draw").

<img width="467" alt="image" src="https://github.com/user-attachments/assets/8b12a4c6-4d49-41d1-8ea2-cc6869726632">
